### PR TITLE
Removed all references to instance name.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 GAME_DIR="/appdata/space-engineers/SpaceEngineersDedicated"
 INSTANCES_DIR="/appdata/space-engineers/instances"
 PLUGIN_DIR="/appdata/space-engineers/plugins"
-CONFIG_PATH="${INSTANCES_DIR}/${INSTANCE_NAME}/SpaceEngineers-Dedicated.cfg"
+CONFIG_PATH="${INSTANCES_DIR}/SpaceEngineers-Dedicated.cfg"
 INSTANCE_IP=$(hostname -I | sed "s= ==g")
 
 
@@ -17,7 +17,7 @@ sed -i "s=<IP>.*</IP>=<IP>${INSTANCE_IP}</IP>=g" ${CONFIG_PATH}
 
 # update world save path
 CURRENT_WORLDNAME=$(grep -oEi '<WorldName>(.*)</WorldName>' ${CONFIG_PATH} | sed -E "s=<WorldName>|</WorldName>==g")
-SAVE_PATH="Z:\\\\appdata\\\\space-engineers\\\\instances\\\\${INSTANCE_NAME}\\\\Saves\\\\${CURRENT_WORLDNAME}";
+SAVE_PATH="Z:\\\\appdata\\\\space-engineers\\\\instances\\\\Saves\\\\${CURRENT_WORLDNAME}";
 sed -E -i "s=<LoadWorld />|<LoadWorld.*LoadWorld>=<LoadWorld>${SAVE_PATH}</LoadWorld>=g" ${CONFIG_PATH}
 
 echo "---------------------------------UPDATE PLUGINS------------------------------"
@@ -44,9 +44,9 @@ echo "SAVE_PATH=$SAVE_PATH"
 ## END UPDATES ##
 wine --version
 echo "----------------------------------START GAME---------------------------------"
-rm ${INSTANCES_DIR}/${INSTANCE_NAME}/*.log
+rm ${INSTANCES_DIR}/*.log
 cd ${GAME_DIR}/DedicatedServer64/
-wine SpaceEngineersDedicated.exe -noconsole -ignorelastsession -path Z:\\appdata\\space-engineers\\instances\\${INSTANCE_NAME}
+wine SpaceEngineersDedicated.exe -noconsole -ignorelastsession -path Z:\\appdata\\space-engineers\\instances
 echo "-----------------------------------END GAME----------------------------------"
 sleep 1
 echo "-----------------------------------BYE !!!!----------------------------------"


### PR DESCRIPTION
I couldn't get the container to work, because there was no instance name environment variable.
But even when i did add it, the container didn't work.

Removing it seemed to fix it.

This fixes the message of `Unable to find the specified file.`
Which was Space Engineers trying to save some world data.

Note: This fixes things for Unraid