### PR TITLE
healthcheck Added dynamic IP determination

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,5 @@ services:
     environment: 
       - WINEDEBUG=-all
       - INSTANCE_NAME=SE
-      - PUBLIC_IP=127.0.0.1
-      # public ip required for healthcheck
+      - PUBLIC_IP=0.0.0.0
+      # public ip required for healthcheck. 0.0.0.0 for automatic determine your IP.

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,12 +2,18 @@
 # Now the if clause checks the syntax of $PUBLIC_IP . If $PUBLIC_IP is is 0.0.0.0, dynamic check the Public IP or elif fixed PUBLIC_IP in docker-compose.yml, else exit 1.
 if [[ "${PUBLIC_IP}" =~ 0.0.0.0 ]] ; then
         # Added a curl to get own public IP for dynamic IPv4 Line 4
-        curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=$(curl -s https://api.ipify.org) -qq | grep Space -q
-        exit 0
+        if curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=$(curl -s https://api.ipify.org) -qq | grep Space -q ; then
+                exit 0
+        else
+                exit 1
+        fi
         # Here added Regex check for a correct IPv4
 elif [[ "${PUBLIC_IP}" =~ ^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})){3}$ ]] ; then
-        curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=${PUBLIC_IP} -qq | grep Space -q
-        exit 0
+        if curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=${PUBLIC_IP} -qq | grep Space -q; then
+                exit 0
+        else
+                exit 1
+        fi
 else
-        exit 1
+        exit 2
 fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-
-if curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=${PUBLIC_IP} -qq | grep Space -q
-then
+# Now the if clause checks the syntax of $PUBLIC_IP . If $PUBLIC_IP is is 0.0.0.0, dynamic check the Public IP or elif fixed PUBLIC_IP in docker-compose.yml, else exit 1.
+if [[ "${PUBLIC_IP}" =~ 0.0.0.0 ]] ; then
+        # Added a curl to get own public IP for dynamic IPv4 Line 4
+        curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=$(curl -s https://api.ipify.org) -qq | grep Space -q
+        exit 0
+        # Here added Regex check for a correct IPv4
+elif [[ "${PUBLIC_IP}" =~ ^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})){3}$ ]] ; then
+        curl https://api.steampowered.com/ISteamApps/GetServersAtAddress/v1?addr=${PUBLIC_IP} -qq | grep Space -q
         exit 0
 else
         exit 1


### PR DESCRIPTION
Overworked the healthcheck. Now the healthcheck.sh is able to detect the public ip automatically, if $PUBLIC_IP is 0.0.0.0 and added a regex check for valid IPv4.